### PR TITLE
hpal run

### DIFF
--- a/lib/commands/index.js
+++ b/lib/commands/index.js
@@ -3,3 +3,4 @@
 exports.docs = require('./docs');
 exports.make = require('./make');
 exports.new = require('./new');
+exports.run = require('./run');

--- a/lib/commands/run.js
+++ b/lib/commands/run.js
@@ -21,25 +21,27 @@ module.exports = (cwd, list, cmd, args, ctx) => {
             if (list) {
 
                 const pluginNames = Object.keys(server.plugins);
-                const commands = pluginNames.reduce((collect, pluginName) => {
+                const commandList = pluginNames.reduce((collect, pluginName) => {
 
-                    const { commands: cmds } = server.plugins[pluginName];
+                    const plugin = server.plugins[pluginName];
+                    const commands = Object.keys(plugin.commands || {}).map((cmdName) => {
 
-                    const fullCmds = Object.keys(cmds || {}).map((cmd) => ({
-                        name: (cmd === 'default') ? pluginName : internals.kebabize(`${pluginName}:${cmd}`),
-                        description: internals.normalizeCommand(cmds[cmd]).description
-                    }));
+                        const name = pluginName.replace(/^hpal-/i, '') + ((cmdName === 'default') ? '' : internals.kebabize(`:${cmdName}`));
+                        const { description } = internals.normalizeCommand(plugin.commands[cmdName]);
 
-                    return collect.concat(fullCmds);
+                        return { name, description };
+                    });
+
+                    return collect.concat(commands);
                 }, []);
 
-                if (!commands.length) {
+                if (!commandList.length) {
                     ctx.output(ctx.colors.yellow('No commands found on your server.'));
                 }
                 else {
-                    ctx.output(ctx.colors.green(`Here are some commands we found on your server:`));
+                    ctx.output(ctx.colors.green('Here are some commands we found on your server:'));
                     ctx.output('');
-                    ctx.output(commands.map(({ name, description }) => `  hpal run ${name}\n` + (description ? `    - ${description}\n` : '')));
+                    ctx.output(commandList.map(({ name, description }) => ctx.colors.bold(`  hpal run ${name}\n`) + (description ? `    • ${description}\n` : '')));
                 }
 
                 return server;
@@ -47,11 +49,10 @@ module.exports = (cwd, list, cmd, args, ctx) => {
 
             const pluginName = cmd.split(':')[0];
             const rawCommandName = cmd.slice(pluginName.length + 1) || 'default';
-            const commandName = rawCommandName.split(':').map(internals.camelize).join(':');
+            const commandName = internals.camelize(rawCommandName);
             const commandInfo = internals.normalizeCommand(
-                server.plugins[pluginName] &&
-                server.plugins[pluginName].commands &&
-                server.plugins[pluginName].commands[commandName]
+                internals.getCommand(server, commandName, pluginName) ||
+                internals.getCommand(server, commandName, `hpal-${pluginName}`)
             );
 
             if (!commandInfo || typeof commandInfo.command !== 'function') {
@@ -93,6 +94,7 @@ internals.getServer = (root, ctx) => {
 
 internals.kebabize = (str) => str.replace(/[A-Z]/g, (m) => (`-${m}`).toLowerCase());
 internals.camelize = (str) => str.replace(/[_-]./g, (m) => m[1].toUpperCase());
+
 internals.normalizeCommand = (command) => {
 
     if (typeof command === 'function') {
@@ -100,4 +102,11 @@ internals.normalizeCommand = (command) => {
     }
 
     return command;
+};
+
+internals.getCommand = (server, commandName, pluginName) => {
+
+    return server.plugins[pluginName] &&
+        server.plugins[pluginName].commands &&
+        server.plugins[pluginName].commands[commandName];
 };

--- a/lib/commands/run.js
+++ b/lib/commands/run.js
@@ -31,7 +31,7 @@ module.exports = (cwd, list, cmd, args, ctx) => {
                     const commands = Object.keys(plugin.commands || {}).map((cmdName) => {
 
                         const name = pluginName.replace(/^hpal-/, '') + ((cmdName === 'default') ? '' : internals.kebabize(`:${cmdName}`));
-                        const { description } = internals.normalizeCommand(plugin.commands[cmdName]);
+                        const description = internals.normalizeCommand(plugin.commands[cmdName]).description;
 
                         return { name, description };
                     });
@@ -45,7 +45,7 @@ module.exports = (cwd, list, cmd, args, ctx) => {
                 else {
                     ctx.output(ctx.colors.green('Here are some commands we found on your server:'));
                     ctx.output('');
-                    ctx.output(commandList.map(({ name, description }) => ctx.colors.bold(`  hpal run ${name}\n`) + (description ? `    • ${description}\n` : '')).join(''));
+                    ctx.output(commandList.map((command) => ctx.colors.bold(`  hpal run ${command.name}\n`) + (command.description ? `    • ${command.description}\n` : '')).join(''));
                 }
 
                 return server;

--- a/lib/commands/run.js
+++ b/lib/commands/run.js
@@ -43,7 +43,7 @@ module.exports = (cwd, list, cmd, args, ctx) => {
                     ctx.output(ctx.colors.yellow('No commands found on your server.'));
                 }
                 else {
-                    ctx.output(ctx.colors.green('Here are some commands we found on your server:'));
+                    ctx.output(ctx.colors.green('Here are some commands found on your server:'));
                     ctx.output('');
                     ctx.output(commandList.map((command) => ctx.colors.bold(`  hpal run ${command.name}\n`) + (command.description ? `    • ${command.description}\n` : '')).join(''));
                 }
@@ -79,7 +79,7 @@ internals.getServer = (root, ctx) => {
         const srv = require(`${root}/server`);
 
         if (typeof srv.deployment !== 'function') {
-            throw new DisplayError(ctx.colors.red(`No server found! To run commands the current project must export { deployment: async () => server } from ${root}/server[.js].`));
+            throw new DisplayError(ctx.colors.red(`No server found! To run commands the current project must export { deployment: async () => server } from ${root}/server.`));
         }
 
         return Promise.resolve()
@@ -89,7 +89,7 @@ internals.getServer = (root, ctx) => {
     catch (err) {
 
         if (err.code === 'MODULE_NOT_FOUND') {
-            throw new DisplayError(ctx.colors.red(`No server found! To run commands the current project must export { deployment: async () => server } from ${root}/server[.js].`));
+            throw new DisplayError(ctx.colors.red(`No server found! To run commands the current project must export { deployment: async () => server } from ${root}/server.`));
         }
 
         throw err;

--- a/lib/commands/run.js
+++ b/lib/commands/run.js
@@ -68,7 +68,20 @@ module.exports = (cwd, list, cmd, args, ctx) => {
             return Promise.resolve()
                 .then(() => commandInfo.command(server, args, root, ctx))
                 .then(() => ctx.output(ctx.colors.green('\nComplete!')))
-                .then(() => server);
+                .then(() => server)
+                .catch((err) => {
+
+                    const rethrow = () => {
+
+                        throw err;
+                    };
+
+                    if (err instanceof DisplayError) {
+                        return server.stop().then(rethrow);
+                    }
+
+                    return rethrow();
+                });
         })
         .then((server) => server.stop());
 };

--- a/lib/commands/run.js
+++ b/lib/commands/run.js
@@ -1,0 +1,103 @@
+'use strict';
+
+const PkgDir = require('pkg-dir');
+const DisplayError = require('../display-error');
+
+const internals = {};
+
+module.exports = (cwd, list, cmd, args, ctx) => {
+
+    return PkgDir(cwd)
+        .then((root) => {
+
+            if (!root) {
+                throw new DisplayError(ctx.colors.red('No nearby package.json found– you don\'t seem to be in a project.'));
+            }
+
+            return internals.getServer(root, ctx);
+        })
+        .then((server) => {
+
+            if (list) {
+
+                const pluginNames = Object.keys(server.plugins);
+                const commands = pluginNames.reduce((collect, pluginName) => {
+
+                    const { commands: cmds } = server.plugins[pluginName];
+
+                    const fullCmds = Object.keys(cmds || {}).map((cmd) => ({
+                        name: (cmd === 'default') ? pluginName : internals.kebabize(`${pluginName}:${cmd}`),
+                        description: internals.normalizeCommand(cmds[cmd]).description
+                    }));
+
+                    return collect.concat(fullCmds);
+                }, []);
+
+                if (!commands.length) {
+                    ctx.output(ctx.colors.yellow('No commands found on your server.'));
+                }
+                else {
+                    ctx.output(ctx.colors.green(`Here are some commands we found on your server:`));
+                    ctx.output('');
+                    ctx.output(commands.map(({ name, description }) => `  hpal run ${name}\n` + (description ? `    - ${description}\n` : '')));
+                }
+
+                return server;
+            }
+
+            const pluginName = cmd.split(':')[0];
+            const rawCommandName = cmd.slice(pluginName.length + 1) || 'default';
+            const commandName = rawCommandName.split(':').map(internals.camelize).join(':');
+            const commandInfo = internals.normalizeCommand(
+                server.plugins[pluginName] &&
+                server.plugins[pluginName].commands &&
+                server.plugins[pluginName].commands[commandName]
+            );
+
+            if (!commandInfo || typeof commandInfo.command !== 'function') {
+                throw new DisplayError(ctx.colors.red(`Plugin ${pluginName} does not have ` + (rawCommandName === 'default') ? 'a default command.' : `the command "${rawCommandName}".`));
+            }
+
+            ctx.output(ctx.colors.green(`Running ${cmd}...\n`));
+
+            return Promise.resolve()
+                .then(() => commandInfo.command(server, args, root, ctx))
+                .then(() => ctx.output(ctx.colors.green('\nComplete!')))
+                .then(() => server);
+        })
+        .then((server) => server.stop());
+};
+
+internals.getServer = (root, ctx) => {
+
+    try {
+        const srv = require(`${root}/server`);
+
+        if (typeof srv.deployment !== 'function') {
+            throw new DisplayError(ctx.colors.red(`No server found! To run commands the current project must export { deployment: async () => server } from ${root}/server[.js].`));
+        }
+
+        return Promise.resolve()
+            .then(() => srv.deployment())
+            .then((server) => server.initialize().then(() => server));
+    }
+    catch (err) {
+
+        if (err.code === 'MODULE_NOT_FOUND') {
+            throw new DisplayError(ctx.colors.red(`No server found! To run commands the current project must export { deployment: async () => server } from ${root}/server[.js].`));
+        }
+
+        throw err;
+    }
+};
+
+internals.kebabize = (str) => str.replace(/[A-Z]/g, (m) => (`-${m}`).toLowerCase());
+internals.camelize = (str) => str.replace(/[_-]./g, (m) => m[1].toUpperCase());
+internals.normalizeCommand = (command) => {
+
+    if (typeof command === 'function') {
+        return { command };
+    }
+
+    return command;
+};

--- a/lib/commands/run.js
+++ b/lib/commands/run.js
@@ -7,8 +7,12 @@ const internals = {};
 
 module.exports = (cwd, list, cmd, args, ctx) => {
 
+    let root;
+
     return PkgDir(cwd)
-        .then((root) => {
+        .then((result) => {
+
+            root = result;
 
             if (!root) {
                 throw new DisplayError(ctx.colors.red('No nearby package.json found– you don\'t seem to be in a project.'));
@@ -26,7 +30,7 @@ module.exports = (cwd, list, cmd, args, ctx) => {
                     const plugin = server.plugins[pluginName];
                     const commands = Object.keys(plugin.commands || {}).map((cmdName) => {
 
-                        const name = pluginName.replace(/^hpal-/i, '') + ((cmdName === 'default') ? '' : internals.kebabize(`:${cmdName}`));
+                        const name = pluginName.replace(/^hpal-/, '') + ((cmdName === 'default') ? '' : internals.kebabize(`:${cmdName}`));
                         const { description } = internals.normalizeCommand(plugin.commands[cmdName]);
 
                         return { name, description };
@@ -41,7 +45,7 @@ module.exports = (cwd, list, cmd, args, ctx) => {
                 else {
                     ctx.output(ctx.colors.green('Here are some commands we found on your server:'));
                     ctx.output('');
-                    ctx.output(commandList.map(({ name, description }) => ctx.colors.bold(`  hpal run ${name}\n`) + (description ? `    • ${description}\n` : '')));
+                    ctx.output(commandList.map(({ name, description }) => ctx.colors.bold(`  hpal run ${name}\n`) + (description ? `    • ${description}\n` : '')).join(''));
                 }
 
                 return server;
@@ -56,7 +60,7 @@ module.exports = (cwd, list, cmd, args, ctx) => {
             );
 
             if (!commandInfo || typeof commandInfo.command !== 'function') {
-                throw new DisplayError(ctx.colors.red(`Plugin ${pluginName} does not have ` + (rawCommandName === 'default') ? 'a default command.' : `the command "${rawCommandName}".`));
+                throw new DisplayError(ctx.colors.red(`Plugin ${pluginName} does not have ` + ((rawCommandName === 'default') ? 'a default command.' : `the command "${rawCommandName}".`)));
             }
 
             ctx.output(ctx.colors.green(`Running ${cmd}...\n`));

--- a/lib/index.js
+++ b/lib/index.js
@@ -17,11 +17,11 @@ exports.start = (options) => {
 
     const output = (str) => options.out.write(`${str}\n`);
     const colors = Print.colors(options.colors);
-    const ctx = { options, colors, output };
+    const ctx = { options, colors, output, DisplayError };
 
     output(''); // Just a newline to make some room
 
-    const extraArgs = (args instanceof Error) ? options.argv.slice(2) : args._;
+    const extraArgs = (args instanceof Error) ? options.argv : args._;
     const commandAndPart = extraArgs[2];
 
     if (args instanceof Error && commandAndPart !== 'run') {

--- a/lib/index.js
+++ b/lib/index.js
@@ -21,19 +21,21 @@ exports.start = (options) => {
 
     output(''); // Just a newline to make some room
 
-    const extraArgs = (args instanceof Error) ? options.argv : args._;
-    const commandAndPart = extraArgs[2];
+    const commandAndPart = (args instanceof Error) ? options.argv[2] : args._[2];
+    const extraArgs = (commandAndPart === 'run') ? options.argv : args._;
 
-    if (args instanceof Error && commandAndPart !== 'run') {
-        throw new DisplayError(`${internals.usage(ctx)}\n\n` + colors.red(args.message));
-    }
+    if (commandAndPart !== 'run') {
+        if (args instanceof Error) {
+            throw new DisplayError(`${internals.usage(ctx)}\n\n` + colors.red(args.message));
+        }
 
-    if (args.version) {
-        return output(Package.version);
-    }
+        if (args.version) {
+            return output(Package.version);
+        }
 
-    if (args.help || !commandAndPart) {
-        return output(`${internals.usage(ctx)}\n`);
+        if (args.help || !commandAndPart) {
+            return output(`${internals.usage(ctx)}\n`);
+        }
     }
 
     const command = commandAndPart.split(':')[0];
@@ -147,7 +149,7 @@ internals.definition = {
     list: {
         type: 'boolean',
         alias: 'l',
-        description: '[run] lists all available commands',
+        description: '[run] lists all available commands on your server',
         default: null
     }
 };
@@ -169,5 +171,5 @@ Commands:
     ${ctx.colors.yellow('e.g.')} hpal docs --ver 17.2.0 h.continue
 
   ${ctx.colors.green('hpal run')} [--list] <cmd> [<cmd-options>]
-    ${ctx.colors.yellow('e.g.')} hpal run schwifty:migrations
+    ${ctx.colors.yellow('e.g.')} hpal run plugin-name:command-name
 `;

--- a/lib/index.js
+++ b/lib/index.js
@@ -17,15 +17,16 @@ exports.start = (options) => {
 
     const output = (str) => options.out.write(`${str}\n`);
     const colors = Print.colors(options.colors);
-    const ctx = { options, colors };
+    const ctx = { options, colors, output };
 
     output(''); // Just a newline to make some room
 
-    if (args instanceof Error) {
+    const extraArgs = (args instanceof Error) ? options.argv.slice(2) : args._;
+    const commandAndPart = extraArgs[2];
+
+    if (args instanceof Error && commandAndPart !== 'run') {
         throw new DisplayError(`${internals.usage(ctx)}\n\n` + colors.red(args.message));
     }
-
-    const commandAndPart = args._[2];
 
     if (args.version) {
         return output(Package.version);
@@ -46,8 +47,8 @@ exports.start = (options) => {
             }
 
             const cwd = options.cwd;
-            const place = args._[3];
-            const name = args._[4];
+            const place = extraArgs[3];
+            const name = extraArgs[4];
             const asDir = args.asDir ? true : (args.asFile ? false : null);
 
             return Commands.make(cwd, place, name, asDir, ctx)
@@ -61,8 +62,8 @@ exports.start = (options) => {
             const cwd = options.cwd;
             const pkg = cmdPart || 'hapi';
             const version = args.ver;
-            const query = args._[3];
-            const itemQuery = args._[4];
+            const query = extraArgs[3];
+            const itemQuery = extraArgs[4];
 
             if (!query) {
                 throw new DisplayError(colors.red(`You must specify a search query to find a section in the ${pkg} docs.`));
@@ -80,18 +81,31 @@ exports.start = (options) => {
         }
         case 'new': {
 
-            if (!args._[3]) {
+            if (!extraArgs[3]) {
                 throw new DisplayError(colors.red('You must specify a directory in which to start your project.'));
             }
 
             const cwd = options.cwd;
-            const dir = Path.resolve(cwd, args._[3]);
+            const dir = Path.resolve(cwd, extraArgs[3]);
 
             return Commands.new(cwd, dir, ctx)
                 .then(() => {
 
                     output(colors.green(`New pal project created in ${Path.relative(cwd, dir)}`));
                 });
+        }
+        case 'run': {
+
+            const cwd = options.cwd;
+            const list = args.list;
+            const cmd = extraArgs[3];
+            const normalizedArgs = extraArgs.slice(4);
+
+            if (!cmd && !list) {
+                throw new DisplayError(colors.red('You must specify a command to run.'));
+            }
+
+            return Commands.run(cwd, list, cmd, normalizedArgs, ctx);
         }
         default: {
             throw new DisplayError(`${internals.usage(ctx)}\n\n` + colors.red(`Unknown command: ${command}`));
@@ -129,6 +143,12 @@ internals.definition = {
         alias: 'V',
         description: '[docs] specifies the version/ref of the API docs to search for the given package',
         default: null
+    },
+    list: {
+        type: 'boolean',
+        alias: 'l',
+        description: '[run] lists all available commands',
+        default: null
     }
 };
 
@@ -147,4 +167,7 @@ Commands:
 
   ${ctx.colors.green('hpal docs')}[:<package-name>] [--ver x.y.z|ref] <docs-section> [<config-item>]
     ${ctx.colors.yellow('e.g.')} hpal docs --ver 17.2.0 h.continue
+
+  ${ctx.colors.green('hpal run')} [--list] <cmd> [<cmd-options>]
+    ${ctx.colors.yellow('e.g.')} hpal run schwifty:migrations
 `;

--- a/lib/print.js
+++ b/lib/print.js
@@ -134,6 +134,7 @@ exports.markdownListItem = (content, headingMatchers, listItemMatcher) => {
 exports.colors = (enabled) => {
 
     const codes = {
+        bold: 1,
         red: 31,
         green: 32,
         yellow: 33,

--- a/test/closet/run-bad-command/node_modules
+++ b/test/closet/run-bad-command/node_modules
@@ -1,0 +1,1 @@
+../../../node_modules

--- a/test/closet/run-bad-command/package.json
+++ b/test/closet/run-bad-command/package.json
@@ -1,0 +1,3 @@
+{
+  "name": "run-bad-command"
+}

--- a/test/closet/run-bad-command/server.js
+++ b/test/closet/run-bad-command/server.js
@@ -1,0 +1,23 @@
+'use strict';
+
+const Hapi = require('hapi');
+
+exports.deployment = () => {
+
+    const server = new Hapi.Server();
+
+    const plugin = (srv, options, next) => {
+
+        srv.expose('commands', {
+            'bad-command': {}
+        });
+
+        return next();
+    };
+
+    plugin.attributes = {
+        name: 'x'
+    };
+
+    return server.register(plugin).then(() => server);
+};

--- a/test/closet/run-bad-server/node_modules
+++ b/test/closet/run-bad-server/node_modules
@@ -1,0 +1,1 @@
+../../../node_modules

--- a/test/closet/run-bad-server/package.json
+++ b/test/closet/run-bad-server/package.json
@@ -1,0 +1,3 @@
+{
+  "name": "run-bad-server"
+}

--- a/test/closet/run-bad-server/server.js
+++ b/test/closet/run-bad-server/server.js
@@ -1,0 +1,3 @@
+'use strict';
+
+exports.deployment = {};

--- a/test/closet/run-command-bad-error/node_modules
+++ b/test/closet/run-command-bad-error/node_modules
@@ -1,0 +1,1 @@
+../../../node_modules

--- a/test/closet/run-command-bad-error/package.json
+++ b/test/closet/run-command-bad-error/package.json
@@ -1,0 +1,3 @@
+{
+  "name": "run-command-bad-error"
+}

--- a/test/closet/run-command-bad-error/server.js
+++ b/test/closet/run-command-bad-error/server.js
@@ -1,0 +1,42 @@
+'use strict';
+
+const Hapi = require('hapi');
+
+exports.deployment = () => {
+
+    const server = new Hapi.Server();
+
+    const plugin = (srv, options, next) => {
+
+        srv.expose('commands', {
+            someCommand: (cmdSrv, args, root, ctx) => {
+
+                return Promise.resolve().then(() => {
+
+                    ctx.options.cmd = [cmdSrv, args, root, ctx];
+
+                    const stop = cmdSrv.stop;
+                    cmdSrv.stop = () => {
+
+                        cmdSrv.stop = stop;
+
+                        return cmdSrv.stop().then(() => {
+
+                            cmdSrv.stopped = true;
+                        });
+                    };
+
+                    throw new Error('Something happened');
+                });
+            }
+        });
+
+        return next();
+    };
+
+    plugin.attributes = {
+        name: 'x'
+    };
+
+    return server.register(plugin).then(() => server);
+};

--- a/test/closet/run-command-display-error/node_modules
+++ b/test/closet/run-command-display-error/node_modules
@@ -1,0 +1,1 @@
+../../../node_modules

--- a/test/closet/run-command-display-error/package.json
+++ b/test/closet/run-command-display-error/package.json
@@ -1,0 +1,3 @@
+{
+  "name": "run-command-display-error"
+}

--- a/test/closet/run-command-display-error/server.js
+++ b/test/closet/run-command-display-error/server.js
@@ -1,0 +1,42 @@
+'use strict';
+
+const Hapi = require('hapi');
+
+exports.deployment = () => {
+
+    const server = new Hapi.Server();
+
+    const plugin = (srv, options, next) => {
+
+        srv.expose('commands', {
+            someCommand: (cmdSrv, args, root, ctx) => {
+
+                return Promise.resolve().then(() => {
+
+                    ctx.options.cmd = [cmdSrv, args, root, ctx];
+
+                    const stop = cmdSrv.stop;
+                    cmdSrv.stop = () => {
+
+                        cmdSrv.stop = stop;
+
+                        return cmdSrv.stop().then(() => {
+
+                            cmdSrv.stopped = true;
+                        });
+                    };
+
+                    throw new ctx.DisplayError('Something happened');
+                });
+            }
+        });
+
+        return next();
+    };
+
+    plugin.attributes = {
+        name: 'x'
+    };
+
+    return server.register(plugin).then(() => server);
+};

--- a/test/closet/run-command/node_modules
+++ b/test/closet/run-command/node_modules
@@ -1,0 +1,1 @@
+../../../node_modules

--- a/test/closet/run-command/package.json
+++ b/test/closet/run-command/package.json
@@ -1,0 +1,3 @@
+{
+  "name": "run-command"
+}

--- a/test/closet/run-command/server.js
+++ b/test/closet/run-command/server.js
@@ -14,6 +14,17 @@ exports.deployment = () => {
                 return Promise.resolve().then(() => {
 
                     ctx.options.cmd = [cmdSrv, args, root, ctx];
+
+                    const stop = cmdSrv.stop;
+                    cmdSrv.stop = () => {
+
+                        cmdSrv.stop = stop;
+
+                        return cmdSrv.stop().then(() => {
+
+                            cmdSrv.stopped = true;
+                        });
+                    };
                 });
             }
         });

--- a/test/closet/run-command/server.js
+++ b/test/closet/run-command/server.js
@@ -1,0 +1,29 @@
+'use strict';
+
+const Hapi = require('hapi');
+
+exports.deployment = () => {
+
+    const server = new Hapi.Server();
+
+    const plugin = (srv, options, next) => {
+
+        srv.expose('commands', {
+            someCommand: (cmdSrv, args, root, ctx) => {
+
+                return Promise.resolve().then(() => {
+
+                    ctx.options.cmd = [cmdSrv, args, root, ctx];
+                });
+            }
+        });
+
+        return next();
+    };
+
+    plugin.attributes = {
+        name: 'x'
+    };
+
+    return server.register(plugin).then(() => server);
+};

--- a/test/closet/run-default-command/node_modules
+++ b/test/closet/run-default-command/node_modules
@@ -1,0 +1,1 @@
+../../../node_modules

--- a/test/closet/run-default-command/package.json
+++ b/test/closet/run-default-command/package.json
@@ -1,0 +1,3 @@
+{
+  "name": "run-default-command"
+}

--- a/test/closet/run-default-command/server.js
+++ b/test/closet/run-default-command/server.js
@@ -1,0 +1,26 @@
+'use strict';
+
+const Hapi = require('hapi');
+
+exports.deployment = () => {
+
+    const server = new Hapi.Server();
+
+    const plugin = (srv, options, next) => {
+
+        srv.expose('commands', {
+            default: (cmdSrv, args, root, ctx) => {
+
+                ctx.options.cmd = 'ran';
+            }
+        });
+
+        return next();
+    };
+
+    plugin.attributes = {
+        name: 'x'
+    };
+
+    return server.register(plugin).then(() => server);
+};

--- a/test/closet/run-list-commands/node_modules
+++ b/test/closet/run-list-commands/node_modules
@@ -1,0 +1,1 @@
+../../../node_modules

--- a/test/closet/run-list-commands/package.json
+++ b/test/closet/run-list-commands/package.json
@@ -1,0 +1,3 @@
+{
+  "name": "run-list-commands"
+}

--- a/test/closet/run-list-commands/server.js
+++ b/test/closet/run-list-commands/server.js
@@ -1,0 +1,61 @@
+'use strict';
+
+const Hapi = require('hapi');
+
+exports.deployment = () => {
+
+    const server = new Hapi.Server();
+
+    const pluginX = (srv, options, next) => {
+
+        srv.expose('commands', {
+            default: () => null,
+            camelCased: () => null,
+            described: {
+                description: 'This is what I do',
+                command: () => null
+            }
+        });
+
+        return next();
+    };
+
+    pluginX.attributes = {
+        name: 'x'
+    };
+
+    // hpal-prefixed plugin name
+
+    const pluginY = (srv, options, next) => {
+
+        srv.expose('commands', {
+            default: () => null,
+            camelCased: () => null,
+            described: {
+                description: 'This is what I do',
+                command: () => null
+            }
+        });
+
+        return next();
+    };
+
+    pluginY.attributes = {
+        name: 'hpal-y'
+    };
+
+    // Exposes something but no commands
+
+    const pluginZ = (srv, options, next) => {
+
+        srv.expose('irrelevant', null);
+
+        return next();
+    };
+
+    pluginZ.attributes = {
+        name: 'z'
+    };
+
+    return server.register([pluginX, pluginY, pluginZ]).then(() => server);
+};

--- a/test/closet/run-list-no-commands/node_modules
+++ b/test/closet/run-list-no-commands/node_modules
@@ -1,0 +1,1 @@
+../../../node_modules

--- a/test/closet/run-list-no-commands/package.json
+++ b/test/closet/run-list-no-commands/package.json
@@ -1,0 +1,3 @@
+{
+  "name": "run-list-no-commands"
+}

--- a/test/closet/run-list-no-commands/server.js
+++ b/test/closet/run-list-no-commands/server.js
@@ -1,0 +1,5 @@
+'use strict';
+
+const Hapi = require('hapi');
+
+exports.deployment = () => new Hapi.Server();

--- a/test/closet/run-no-command/node_modules
+++ b/test/closet/run-no-command/node_modules
@@ -1,0 +1,1 @@
+../../../node_modules

--- a/test/closet/run-no-command/package.json
+++ b/test/closet/run-no-command/package.json
@@ -1,0 +1,3 @@
+{
+  "name": "run-no-command"
+}

--- a/test/closet/run-no-command/server.js
+++ b/test/closet/run-no-command/server.js
@@ -1,0 +1,21 @@
+'use strict';
+
+const Hapi = require('hapi');
+
+exports.deployment = () => {
+
+    const server = new Hapi.Server();
+
+    const plugin = (srv, options, next) => {
+
+        srv.expose('irrelevant', null);
+
+        return next();
+    };
+
+    plugin.attributes = {
+        name: 'y'
+    };
+
+    return server.register(plugin).then(() => server);
+};

--- a/test/closet/run-no-server/node_modules
+++ b/test/closet/run-no-server/node_modules
@@ -1,0 +1,1 @@
+../../../node_modules

--- a/test/closet/run-no-server/package.json
+++ b/test/closet/run-no-server/package.json
@@ -1,0 +1,3 @@
+{
+  "name": "run-no-server"
+}

--- a/test/closet/run-prefixed-command/node_modules
+++ b/test/closet/run-prefixed-command/node_modules
@@ -1,0 +1,1 @@
+../../../node_modules

--- a/test/closet/run-prefixed-command/package.json
+++ b/test/closet/run-prefixed-command/package.json
@@ -1,0 +1,3 @@
+{
+  "name": "run-default-command"
+}

--- a/test/closet/run-prefixed-command/package.json
+++ b/test/closet/run-prefixed-command/package.json
@@ -1,3 +1,3 @@
 {
-  "name": "run-default-command"
+  "name": "run-prefixed-command"
 }

--- a/test/closet/run-prefixed-command/server.js
+++ b/test/closet/run-prefixed-command/server.js
@@ -1,0 +1,26 @@
+'use strict';
+
+const Hapi = require('hapi');
+
+exports.deployment = () => {
+
+    const server = new Hapi.Server();
+
+    const plugin = (srv, options, next) => {
+
+        srv.expose('commands', {
+            someCommand: (cmdSrv, args, root, ctx) => {
+
+                ctx.options.cmd = 'ran';
+            }
+        });
+
+        return next();
+    };
+
+    plugin.attributes = {
+        name: 'hpal-x'
+    };
+
+    return server.register(plugin).then(() => server);
+};

--- a/test/index.js
+++ b/test/index.js
@@ -1325,7 +1325,7 @@ describe('hpal', () => {
 
                         expect(result.err).to.be.instanceof(DisplayError);
                         expect(result.output).to.equal('');
-                        expect(result.errorOutput).to.contain(`No server found! To run commands the current project must export { deployment: async () => server } from ${root}/server[.js].`);
+                        expect(result.errorOutput).to.contain(`No server found! To run commands the current project must export { deployment: async () => server } from ${root}/server.`);
                     });
             });
 
@@ -1338,7 +1338,7 @@ describe('hpal', () => {
 
                         expect(result.err).to.be.instanceof(DisplayError);
                         expect(result.output).to.equal('');
-                        expect(result.errorOutput).to.contain(`No server found! To run commands the current project must export { deployment: async () => server } from ${root}/server[.js].`);
+                        expect(result.errorOutput).to.contain(`No server found! To run commands the current project must export { deployment: async () => server } from ${root}/server.`);
                     });
             });
 
@@ -1383,7 +1383,7 @@ describe('hpal', () => {
                         const output = StripAnsi(result.output).trim();
 
                         expect(output).to.equal([
-                            'Here are some commands we found on your server:',
+                            'Here are some commands found on your server:',
                             '',
                             '  hpal run x',
                             '  hpal run x:camel-cased',
@@ -1418,13 +1418,28 @@ describe('hpal', () => {
 
                         expect(result.err).to.not.exist();
                         expect(result.errorOutput).to.equal('');
-                        expect(result.output).to.contain('Running x:some-command...');
-                        expect(result.output).to.contain('Complete!');
                         expect(result.options.cmd[0]).to.be.instanceof(Hapi.Server);
                         expect(result.options.cmd[1]).to.equal(['-a', 'arg1', '--arg2', 'arg3']);
                         expect(result.options.cmd[2]).to.equal(Path.resolve(__dirname, 'closet/run-command'));
                         expect(result.options.cmd[3]).to.exist();
                         expect(result.options.cmd[3].options).to.shallow.equal(result.options);
+                        expect(result.output).to.contain('Running x:some-command...');
+                        expect(result.output).to.contain('Complete!');
+
+                        // Test args against flag collision
+                        return RunUtil.cli(['run', 'x:some-command', '--asFile', '-h'], 'run-command');
+                    })
+                    .then((result) => {
+
+                        expect(result.err).to.not.exist();
+                        expect(result.errorOutput).to.equal('');
+                        expect(result.options.cmd[0]).to.be.instanceof(Hapi.Server);
+                        expect(result.options.cmd[1]).to.equal(['--asFile', '-h']);
+                        expect(result.options.cmd[2]).to.equal(Path.resolve(__dirname, 'closet/run-command'));
+                        expect(result.options.cmd[3]).to.exist();
+                        expect(result.options.cmd[3].options).to.shallow.equal(result.options);
+                        expect(result.output).to.contain('Running x:some-command...');
+                        expect(result.output).to.contain('Complete!');
                     });
             });
 

--- a/test/index.js
+++ b/test/index.js
@@ -1454,7 +1454,7 @@ describe('hpal', () => {
                     });
             });
 
-            it('runs a default command.', () => {
+            it('runs an hpal-prefixed command.', () => {
 
                 return RunUtil.cli(['run', 'x:some-command'], 'run-prefixed-command')
                     .then((result) => {

--- a/test/index.js
+++ b/test/index.js
@@ -4,8 +4,10 @@
 
 const Fs = require('fs');
 const Os = require('os');
+const Path = require('path');
 const ChildProcess = require('child_process');
 const Lab = require('lab');
+const Hapi = require('hapi');
 const Pify = require('pify');
 const Rimraf = require('rimraf');
 const StripAnsi = require('strip-ansi');
@@ -544,18 +546,18 @@ describe('hpal', () => {
             const exec = (cmd, cwd) => Pify(ChildProcess.exec, { multiArgs: true })(cmd, { cwd: `${__dirname}/closet/${cwd}` });
             const answerNpmInit = (cli, name, bail) => {
 
-                cli.args.out.on('data', (data) => {
+                cli.options.out.on('data', (data) => {
 
                     data = data.toString();
 
                     if (~data.indexOf('name: ')) {
-                        process.nextTick(() => cli.args.in.write(`${name}\n`));
+                        process.nextTick(() => cli.options.in.write(`${name}\n`));
                     }
                     else if ((/^[\w ]+: /).test(data)) {
-                        process.nextTick(() => cli.args.in.write('\n')); // "Return" through the npm prompts
+                        process.nextTick(() => cli.options.in.write('\n')); // "Return" through the npm prompts
                     }
                     else if (~data.indexOf('Is this ok?')) {
-                        process.nextTick(() => cli.args.in.write(bail ? 'no\n' : 'yes\n'));
+                        process.nextTick(() => cli.options.in.write(bail ? 'no\n' : 'yes\n'));
                     }
                 });
             };
@@ -1130,7 +1132,7 @@ describe('hpal', () => {
 
                         const cli = RunUtil.cli(['docs', 'plugin'], 'single-as-file');
 
-                        cli.args.err.on('data', (data) => {
+                        cli.options.err.on('data', (data) => {
 
                             stderr += data;
                         });
@@ -1290,7 +1292,7 @@ describe('hpal', () => {
             });
         });
 
-        describe.only('run command', () => {
+        describe('run command', () => {
 
             it('errors when there\'s no package.json file found.', () => {
 
@@ -1311,6 +1313,140 @@ describe('hpal', () => {
                         expect(result.err).to.be.instanceof(DisplayError);
                         expect(result.output).to.equal('');
                         expect(result.errorOutput).to.contain('You must specify a command to run.');
+                    });
+            });
+
+            it('errors when there is no server to require.', () => {
+
+                return RunUtil.cli(['run', 'x'], 'run-no-server')
+                    .then((result) => {
+
+                        const root = Path.resolve(__dirname, 'closet/run-no-server');
+
+                        expect(result.err).to.be.instanceof(DisplayError);
+                        expect(result.output).to.equal('');
+                        expect(result.errorOutput).to.contain(`No server found! To run commands the current project must export { deployment: async () => server } from ${root}/server[.js].`);
+                    });
+            });
+
+            it('errors when server does not export { deployment }.', () => {
+
+                return RunUtil.cli(['run', 'x'], 'run-bad-server')
+                    .then((result) => {
+
+                        const root = Path.resolve(__dirname, 'closet/run-bad-server');
+
+                        expect(result.err).to.be.instanceof(DisplayError);
+                        expect(result.output).to.equal('');
+                        expect(result.errorOutput).to.contain(`No server found! To run commands the current project must export { deployment: async () => server } from ${root}/server[.js].`);
+                    });
+            });
+
+            it('errors when calling a vanilla or default command that does not exist.', () => {
+
+                return RunUtil.cli(['run', 'x'], 'run-no-command')
+                    .then((result) => {
+
+                        expect(result.err).to.be.instanceof(DisplayError);
+                        expect(result.output).to.equal('');
+                        expect(result.errorOutput).to.contain('Plugin x does not have a default command.');
+
+                        return RunUtil.cli(['run', 'y:some-command'], 'run-no-command');
+                    })
+                    .then((result) => {
+
+                        expect(result.err).to.be.instanceof(DisplayError);
+                        expect(result.output).to.equal('');
+                        expect(result.errorOutput).to.contain('Plugin y does not have the command "some-command".');
+                    });
+            });
+
+            it('errors when calling a command that is not exported properly.', () => {
+
+                return RunUtil.cli(['run', 'x:bad-command'], 'run-bad-command')
+                    .then((result) => {
+
+                        expect(result.err).to.be.instanceof(DisplayError);
+                        expect(result.output).to.equal('');
+                        expect(result.errorOutput).to.contain('Plugin x does not have the command "bad-command".');
+                    });
+            });
+
+            it('lists all commands found on a server: default, hpal-prefixed, and vanilla.', () => {
+
+                return RunUtil.cli(['run', '--list'], 'run-list-commands')
+                    .then((result) => {
+
+                        expect(result.err).to.not.exist();
+                        expect(result.errorOutput).to.equal('');
+
+                        const output = StripAnsi(result.output).trim();
+
+                        expect(output).to.equal([
+                            'Here are some commands we found on your server:',
+                            '',
+                            '  hpal run x',
+                            '  hpal run x:camel-cased',
+                            '  hpal run x:described',
+                            '    • This is what I do',
+                            '  hpal run y',
+                            '  hpal run y:camel-cased',
+                            '  hpal run y:described',
+                            '    • This is what I do'
+                        ].join('\n'));
+                    });
+            });
+
+            it('lists no commands found on a server.', () => {
+
+                return RunUtil.cli(['run', '--list'], 'run-list-no-commands')
+                    .then((result) => {
+
+                        expect(result.err).to.not.exist();
+                        expect(result.errorOutput).to.equal('');
+
+                        const output = StripAnsi(result.output).trim();
+
+                        expect(output).to.equal('No commands found on your server.');
+                    });
+            });
+
+            it('runs a command, passing the server, normalized args, the project root, etc.', () => {
+
+                return RunUtil.cli(['run', 'x:some-command', '-a', 'arg1', '--arg2', 'arg3'], 'run-command')
+                    .then((result) => {
+
+                        expect(result.err).to.not.exist();
+                        expect(result.errorOutput).to.equal('');
+                        expect(result.output).to.contain('Running x:some-command...');
+                        expect(result.output).to.contain('Complete!');
+                        expect(result.options.cmd[0]).to.be.instanceof(Hapi.Server);
+                        expect(result.options.cmd[1]).to.equal(['-a', 'arg1', '--arg2', 'arg3']);
+                        expect(result.options.cmd[2]).to.equal(Path.resolve(__dirname, 'closet/run-command'));
+                        expect(result.options.cmd[3]).to.exist();
+                        expect(result.options.cmd[3].options).to.shallow.equal(result.options);
+                    });
+            });
+
+            it('runs a default command.', () => {
+
+                return RunUtil.cli(['run', 'x'], 'run-default-command')
+                    .then((result) => {
+
+                        expect(result.err).to.not.exist();
+                        expect(result.errorOutput).to.equal('');
+                        expect(result.options.cmd).to.equal('ran');
+                    });
+            });
+
+            it('runs a default command.', () => {
+
+                return RunUtil.cli(['run', 'x:some-command'], 'run-prefixed-command')
+                    .then((result) => {
+
+                        expect(result.err).to.not.exist();
+                        expect(result.errorOutput).to.equal('');
+                        expect(result.options.cmd).to.equal('ran');
                     });
             });
         });

--- a/test/index.js
+++ b/test/index.js
@@ -1289,6 +1289,31 @@ describe('hpal', () => {
                     .then(done, done);
             });
         });
+
+        describe.only('run command', () => {
+
+            it('errors when there\'s no package.json file found.', () => {
+
+                return RunUtil.cli(['run', 'x'], '/')
+                    .then((result) => {
+
+                        expect(result.err).to.be.instanceof(DisplayError);
+                        expect(result.output).to.equal('');
+                        expect(result.errorOutput).to.contain('No nearby package.json found– you don\'t seem to be in a project.');
+                    });
+            });
+
+            it('errors when command is not specified.', () => {
+
+                return RunUtil.cli(['run'], '/')
+                    .then((result) => {
+
+                        expect(result.err).to.be.instanceof(DisplayError);
+                        expect(result.output).to.equal('');
+                        expect(result.errorOutput).to.contain('You must specify a command to run.');
+                    });
+            });
+        });
     });
 
     describe('bin', () => {

--- a/test/run-util.js
+++ b/test/run-util.js
@@ -81,6 +81,7 @@ exports.cli = (argv, cwd, colors) => {
 
             if (!(err instanceof DisplayError)) {
                 err.output = output;
+                err.options = options;
                 throw err;
             }
 

--- a/test/run-util.js
+++ b/test/run-util.js
@@ -63,7 +63,7 @@ exports.cli = (argv, cwd, colors) => {
         errorOutput += data;
     });
 
-    const args = {
+    const options = {
         argv,
         cwd,
         in: stdin,
@@ -73,8 +73,8 @@ exports.cli = (argv, cwd, colors) => {
     };
 
     const cli = Promise.resolve()
-        .then(() => Hpal.start(args))
-        .then(() => ({ err: null, output, errorOutput }))
+        .then(() => Hpal.start(options))
+        .then(() => ({ err: null, output, errorOutput, options }))
         .catch((err) => {
 
             output = output.trim(); // Ignore leading and trailing whitespace for testing purposes
@@ -84,8 +84,8 @@ exports.cli = (argv, cwd, colors) => {
                 throw err;
             }
 
-            return { err, output, errorOutput: err.message };
+            return { err, output, errorOutput: err.message, options };
         });
 
-    return Object.assign(cli, { args });
+    return Object.assign(cli, { options });
 };


### PR DESCRIPTION
`hpal run` allows a user to run custom commands defined by their server's hapi plugins.

```
  hpal run [--list] <cmd> [<cmd-options>]
    e.g. hpal run plugin-name:command-name
```